### PR TITLE
Prevent card flip spam by only allowing one flip every 400ms

### DIFF
--- a/web/app/(game)/play/Play.tsx
+++ b/web/app/(game)/play/Play.tsx
@@ -82,7 +82,7 @@ const Play = () => {
 			setCanFlip(false);
 			setTimeout(() => {
 				setCanFlip(true);
-			}, 500);
+			}, 400);
 		}
 	};
 

--- a/web/app/(game)/play/Play.tsx
+++ b/web/app/(game)/play/Play.tsx
@@ -8,6 +8,7 @@ import { CardSchema } from "../../../types/Card";
 import { tokenAtom, useStandardAtom } from "../../ClientWrapper";
 import { atomWithReset, useResetAtom } from "jotai/utils";
 import Loader from "../../../components/Loader";
+import { useState } from "react";
 
 const playAtom = atomWithReset({
 	firstCard: 0,
@@ -36,7 +37,6 @@ export const play = async ({
 			useStandard,
 		}),
 	});
-	console.log("1");
 	const data: unknown = await res.json();
 	reset();
 	return await CardSchema.array().parse(data);
@@ -48,6 +48,7 @@ const Play = () => {
 	const resetPlay = useResetAtom(playAtom);
 	const [{ firstCard, secondCard, degrees, flipped }, setPlay] =
 		useAtom(playAtom);
+	const [canFlip, setCanFlip] = useState(true);
 
 	const { data: cards } = useQuery(
 		["play", token, useStandard],
@@ -71,12 +72,18 @@ const Play = () => {
 	};
 
 	const flipCard = () => {
-		setPlay({
-			flipped: !flipped,
-			degrees: degrees - 180,
-			firstCard: flipped ? nextCard(secondCard) : firstCard,
-			secondCard: flipped ? secondCard : nextCard(firstCard),
-		});
+		if (canFlip) {
+			setPlay({
+				flipped: !flipped,
+				degrees: degrees - 180,
+				firstCard: flipped ? nextCard(secondCard) : firstCard,
+				secondCard: flipped ? secondCard : nextCard(firstCard),
+			});
+			setCanFlip(false);
+			setTimeout(() => {
+				setCanFlip(true);
+			}, 500);
+		}
 	};
 
 	if (cards && cards.length < 1) {


### PR DESCRIPTION
## **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

* **What is the current behavior?** (You can also link to an open issue here)
you are allowed to spam the next card which can look bad and flip too fast for visual input

* **What is the new behavior (if this is a feature change)?**
400ms delay on each card flip, allowing for fast flips if necessary but allowing the user to glimpse at each card

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:

