### PR TITLE
Added error=jwt support in confirm, added resend email page for when …

### DIFF
--- a/web/app/(game)/auth/confirm/ConfirmPage.tsx
+++ b/web/app/(game)/auth/confirm/ConfirmPage.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { env } from "../../../../env/client.mjs";
 
 const resendEmail = async (email: string) => {
@@ -17,16 +18,25 @@ const Confirm = ({ email }: { email?: string }) => {
 	return (
 		<main className="flex justify-center items-center flex-col w-full h-[85vh]">
 			<div className="background flex justify-center items-center flex-col">
-				<h1 className="text-3xl font-bold">Please confirm email!</h1>
-				<p className="text-lg my-4 text-center">
+				<h1 className="text-2xl sm:text-3xl font-bold text-center">
+					Please confirm email!
+				</h1>
+				<p className="text-lg mt-4 text-center">
 					To finalize account, please click the link in the email sent
 					to you.
 				</p>
 				{email ? (
-					<button className="gbtn" onClick={() => resendEmail(email)}>
+					<button
+						className="btn mt-6"
+						onClick={() => resendEmail(email)}
+					>
 						Resend email
 					</button>
-				) : null}
+				) : (
+					<Link href="/auth/resend-email" className="btn mt-6">
+						Resend Email
+					</Link>
+				)}
 			</div>
 		</main>
 	);

--- a/web/app/(game)/auth/confirm/page.tsx
+++ b/web/app/(game)/auth/confirm/page.tsx
@@ -1,12 +1,32 @@
+import Link from "next/link";
 import Confirm from "./ConfirmPage";
 
 type Props = {
 	searchParams?: {
 		email?: string;
+		error?: string;
 	};
 };
 
 const Page = async ({ searchParams }: Props) => {
+	if (searchParams?.error === "jwt") {
+		return (
+			<main className="flex justify-center items-center flex-col w-full h-[85vh]">
+				<div className="background flex justify-center items-center flex-col">
+					<h1 className="text-2xl sm:text-3xl font-bold text-center">
+						Error with confirmation!
+					</h1>
+					<p className="text-lg mt-4 text-center">
+						Please retry confirming.
+					</p>
+					<Link href="/auth/resend-email" className="btn mt-6">
+						Resend Email
+					</Link>
+				</div>
+			</main>
+		);
+	}
+
 	return <Confirm email={searchParams?.email} />;
 };
 

--- a/web/app/(game)/auth/resend-email/ResendEmail.tsx
+++ b/web/app/(game)/auth/resend-email/ResendEmail.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+
+export const ResetPasswordEmailSchema = z.object({
+	email: z.string().email(),
+});
+export type ResetPasswordEmail = z.input<typeof ResetPasswordEmailSchema>;
+const resetPasswordEmail = async (input: ResetPasswordEmail) => {
+	await fetch(`${process.env.NEXT_PUBLIC_SERVER_URL}/auth/resend-email`, {
+		method: "POST",
+		headers: {
+			Accept: "application/json",
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify(input),
+	});
+};
+
+const PasswordResetEmail = () => {
+	const router = useRouter();
+	const {
+		register,
+		handleSubmit,
+		formState: { errors },
+		setError,
+	} = useForm<ResetPasswordEmail>({
+		resolver: zodResolver(ResetPasswordEmailSchema),
+	});
+
+	const resetByEmail = useMutation(resetPasswordEmail, {
+		onError: (error: any) => {
+			if (error && error.message)
+				setError("email", { message: error.message });
+		},
+	});
+
+	const onSubmit = (data: ResetPasswordEmail) => {
+		resetByEmail.mutate(data);
+	};
+
+	return (
+		<main className="flex justify-center items-center flex-col w-full h-[85vh]">
+			{resetByEmail.isSuccess ? (
+				<div className="background flex justify-center items-center flex-col">
+					<h1 className="text-3xl font-bold">Check your email!</h1>
+					<p className="text-lg mt-4 text-center">
+						Please check your email for a reset link.
+					</p>
+				</div>
+			) : (
+				<form
+					onSubmit={handleSubmit(onSubmit)}
+					className="form w-full max-w-md background"
+				>
+					<h2 className="text-white font-bold text-2xl sm:text-3xl mb-8 text-center">
+						Resend Confirmation
+					</h2>
+					{errors.email ? (
+						<p className="ebtn mb-4">{errors.email.message}</p>
+					) : null}
+					<label htmlFor="email">Email</label>
+					<input
+						id="email"
+						type="text"
+						className="mb-8 mt-2"
+						{...register("email")}
+					/>
+					<div className="flex">
+						<input
+							type="submit"
+							value="Submit"
+							className="btn mr-2 flex-1"
+						/>
+						<div
+							className="gbtn text-center flex-1"
+							onClick={() => router.back()}
+						>
+							Cancel
+						</div>
+					</div>
+				</form>
+			)}
+		</main>
+	);
+};
+
+export default PasswordResetEmail;

--- a/web/app/(game)/auth/resend-email/page.tsx
+++ b/web/app/(game)/auth/resend-email/page.tsx
@@ -1,0 +1,7 @@
+import ResendEmail from "./ResendEmail";
+
+const Page = async () => {
+	return <ResendEmail />;
+};
+
+export default Page;


### PR DESCRIPTION
* **What is the current behavior?** (You can also link to an open issue here)
no difference when jwt error and no way to resend email other than right after register.

* **What is the new behavior (if this is a feature change)?**
error=jwt support in confirm and resend email page for when users need to resend seperately from registering


